### PR TITLE
Fix for FileCollection exception and missing material type

### DIFF
--- a/OMI Filetypes Library/Formats/Material.cs
+++ b/OMI Filetypes Library/Formats/Material.cs
@@ -41,6 +41,7 @@ namespace OMI.Formats.Material
 
         public static readonly string[] ValidMaterialTypes = new string[]
         {
+            "entity",
             "entity_alphatest",
             "entity_alphatest_change_color",
             "entity_change_color",

--- a/OMI Filetypes Library/Formats/PckFile.FileCollection.cs
+++ b/OMI Filetypes Library/Formats/PckFile.FileCollection.cs
@@ -116,11 +116,14 @@ namespace OMI.Formats.Pck
 
         public void RemoveAll(Predicate<PckFile.FileData> value)
         {
+            List<string> values = new List<string>();
             foreach (PckFile.FileData item in _files.Values)
             {
                 if (value(item))
-                    Remove(item.Filename);
+                    values.Add(item.Filename);
             }
+
+            values.ForEach(v => Remove(v));
         }
 
         public void RemoveAt(int index)


### PR DESCRIPTION
-Fix for modified collection exception in PCKFile.FileCollection
-Added "entity" back to the supported Material types list (I removed it for some reason in a prior pull request)